### PR TITLE
Make rust-ffmpeg useable as a library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swo
 gen/
 target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "rust-ffmpeg"
+name = "ffmpeg"
 version = "0.1.0"
 authors = [ "mewlips@gmail.com" ]
 
@@ -47,10 +47,6 @@ path = "swresample0"
 [dependencies.swscale2]
 
 path = "swscale2"
-
-[[bin]]
-
-name = "rust-ffmpeg"
 
 [dependencies]
 libc = "*"

--- a/examples/versions.rs
+++ b/examples/versions.rs
@@ -1,14 +1,6 @@
-extern crate avutil52;
-extern crate avcodec54;
-extern crate avcodec55;
-extern crate avformat54;
-extern crate avformat55;
-extern crate avdevice54;
-extern crate avdevice55;
-extern crate avfilter3;
-extern crate avfilter4;
-extern crate swresample0;
-extern crate swscale2;
+extern crate ffmpeg;
+
+use ffmpeg::*;
 
 pub fn main() {
     let get_major = |v: u32| {v >> 16};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,23 @@
+pub extern crate avutil52 as ffmpeg_avutil52;
+pub extern crate avcodec54 as ffmpeg_avcodec54;
+pub extern crate avcodec55 as ffmpeg_avcodec55;
+pub extern crate avformat54 as ffmpeg_avformat54;
+pub extern crate avformat55 as ffmpeg_avformat55;
+pub extern crate avdevice54 as ffmpeg_avdevice54;
+pub extern crate avdevice55 as ffmpeg_avdevice55;
+pub extern crate avfilter3 as ffmpeg_avfilter3;
+pub extern crate avfilter4 as ffmpeg_avfilter4;
+pub extern crate swresample0 as ffmpeg_swresample0;
+pub extern crate swscale2 as ffmpeg_swscale2;
+
+pub use ffmpeg_avutil52 as avutil52;
+pub use ffmpeg_avcodec54 as avcodec54;
+pub use ffmpeg_avcodec55 as avcodec55;
+pub use ffmpeg_avformat54 as avformat54;
+pub use ffmpeg_avformat55 as avformat55;
+pub use ffmpeg_avdevice54 as avdevice54;
+pub use ffmpeg_avdevice55 as avdevice55;
+pub use ffmpeg_avfilter3 as avfilter3;
+pub use ffmpeg_avfilter4 as avfilter4;
+pub use ffmpeg_swresample0 as swresample0;
+pub use ffmpeg_swscale2 as swscale2;


### PR DESCRIPTION
This changes the crate name to `ffmpeg`, since dashes aren't supported in crate names, and it becomes cumbersome to import. It also adds a lib which just reexports all the dependent crates. Unfortunately Rust does not yet support `pub extern crate foo` which is why we have to do a weird dance with aliasing the crate as something else and then pulling it in with `pub use ... as` as the original name.
